### PR TITLE
Purescript 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.psc*
 /.purs*
 /.psa*
+/.wercker/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 
 test:
 	pulp test
-	pulp docs -- --format markdown && rm -fr docs && mkdir docs && mv generated-docs/md/{F,AWS*}.md docs/
+	pulp docs -- --format markdown && rm -fr docs && mkdir docs && mv generated-docs/md/F.md generated-docs/md/AWS*.md docs/
 	[ -z "$$(git status --porcelain)" ] || (echo "Generated content not commited" && exit 1)
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 
 test:
 	pulp test
-	pulp docs && rm -fr docs && mv generated-docs docs
+	pulp docs -- --format markdown && rm -fr docs && mkdir docs && mv generated-docs/md/{F,AWS*}.md docs/
 	[ -z "$$(git status --porcelain)" ] || (echo "Generated content not commited" && exit 1)
 
 release:

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ AWS services can be created with a set of options. Most of those are currently s
 - `credentials` is missing
 - `credentialProvider` is missing
 - `logger` is missing
+- `apiVersions` is missing
 
 - `paramValidation` can't be a `Boolean`
 - `apiVersion` can't be a `Date`
-- `apiVersions` can't contain `Date` objects
 
 - `retryDelayOptions` is missing the `customBackoff` property
 - `httpOptions` is missing the `agent` property

--- a/bower.json
+++ b/bower.json
@@ -12,13 +12,16 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.3.0",
-    "purescript-console": "^3.0.0",
-    "purescript-aff": "^4.1.1",
-    "purescript-foreign-generic": "^6.0.0",
-    "purescript-datetime": "^3.4.1"
+    "purescript-prelude": "^4.1.1",
+    "purescript-console": "^4.2.0",
+    "purescript-aff": "^5.1.2",
+    "purescript-foreign-generic": "^10.0.0",
+    "purescript-datetime": "^4.1.1",
+    "purescript-effect": "^2.0.1",
+    "purescript-foreign-object": "^2.0.3",
+    "purescript-exceptions": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/docs/AWS.Request.Types.md
+++ b/docs/AWS.Request.Types.md
@@ -4,7 +4,7 @@
 
 ``` purescript
 newtype NoArguments
-  = NoArguments {  }
+  = NoArguments (Record ())
 ```
 
 ##### Instances

--- a/docs/AWS.Request.md
+++ b/docs/AWS.Request.md
@@ -10,7 +10,7 @@ newtype MethodName
 #### `request`
 
 ``` purescript
-request :: forall eff i o. Encode i => Decode o => Service -> MethodName -> i -> Aff (exception :: EXCEPTION | eff) o
+request :: forall i o. Encode i => Decode o => Service -> MethodName -> i -> Aff o
 ```
 
 

--- a/docs/AWS.Service.md
+++ b/docs/AWS.Service.md
@@ -9,7 +9,7 @@ genericEncode :: forall a rep. Generic a rep => GenericEncode rep => a -> Foreig
 #### `OptionsType`
 
 ``` purescript
-type OptionsType = { params :: Maybe (StrMap String), endpoint :: Maybe String, accessKeyId :: Maybe String, secretAccessKey :: Maybe String, region :: Maybe String, maxRetries :: Maybe Int, maxRedirects :: Maybe Int, sslEnabled :: Maybe Boolean, paramValidation :: Maybe ParamValidation, computeChecksums :: Maybe Boolean, convertResponseTypes :: Maybe Boolean, correctClockSkew :: Maybe Boolean, s3ForcePathStyle :: Maybe Boolean, s3BucketEndpoint :: Maybe Boolean, s3DisableBodySigning :: Maybe Boolean, retryDelayOptions :: Maybe RetryDelayOptions, httpOptions :: Maybe HttpOptions, apiVersion :: Maybe String, apiVersions :: Maybe (StrMap String), systemClockOffset :: Maybe Int, signatureVersion :: Maybe String, signatureCache :: Maybe Boolean, dynamoDbCrc32 :: Maybe Boolean }
+type OptionsType = { accessKeyId :: Maybe String, apiVersion :: Maybe String, computeChecksums :: Maybe Boolean, convertResponseTypes :: Maybe Boolean, correctClockSkew :: Maybe Boolean, dynamoDbCrc32 :: Maybe Boolean, endpoint :: Maybe String, httpOptions :: Maybe HttpOptions, maxRedirects :: Maybe Int, maxRetries :: Maybe Int, paramValidation :: Maybe ParamValidation, params :: Maybe (Object String), region :: Maybe String, retryDelayOptions :: Maybe RetryDelayOptions, s3BucketEndpoint :: Maybe Boolean, s3DisableBodySigning :: Maybe Boolean, s3ForcePathStyle :: Maybe Boolean, secretAccessKey :: Maybe String, signatureCache :: Maybe Boolean, signatureVersion :: Maybe String, sslEnabled :: Maybe Boolean, systemClockOffset :: Maybe Int }
 ```
 
 #### `Options`
@@ -42,7 +42,7 @@ defaultOptions' :: (OptionsType -> OptionsType) -> Options
 #### `ParamValidationType`
 
 ``` purescript
-type ParamValidationType = { min :: Maybe Boolean, max :: Maybe Boolean, pattern :: Maybe Boolean, enum :: Maybe Boolean }
+type ParamValidationType = { enum :: Maybe Boolean, max :: Maybe Boolean, min :: Maybe Boolean, pattern :: Maybe Boolean }
 ```
 
 #### `ParamValidation`
@@ -108,7 +108,7 @@ defaultRetryDelayOptions' :: (RetryDelayOptionsType -> RetryDelayOptionsType) ->
 #### `HttpOptionsType`
 
 ``` purescript
-type HttpOptionsType = { proxy :: Maybe String, connectTimeout :: Maybe Int, timeout :: Maybe Int, xhrAsync :: Maybe Boolean, xhrWithCredentials :: Maybe Boolean }
+type HttpOptionsType = { connectTimeout :: Maybe Int, proxy :: Maybe String, timeout :: Maybe Int, xhrAsync :: Maybe Boolean, xhrWithCredentials :: Maybe Boolean }
 ```
 
 #### `HttpOptions`
@@ -155,13 +155,13 @@ newtype ServiceName
 #### `serviceImpl`
 
 ``` purescript
-serviceImpl :: forall eff. String -> Foreign -> Eff (exception :: EXCEPTION | eff) Foreign
+serviceImpl :: String -> Foreign -> Effect Foreign
 ```
 
 #### `service`
 
 ``` purescript
-service :: forall eff. ServiceName -> Options -> Eff (exception :: EXCEPTION | eff) Service
+service :: ServiceName -> Options -> Effect Service
 ```
 
 

--- a/docs/F.md
+++ b/docs/F.md
@@ -3,7 +3,7 @@
 #### `liftF`
 
 ``` purescript
-liftF :: forall eff a. F a -> Eff (exception :: EXCEPTION | eff) a
+liftF :: forall a. F a -> Effect a
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "integrity": "sha1-GpNzAlPivgJ6S9OvkkjL2gVz3oA=",
             "requires": {
                 "buffer": "4.9.1",
-                "events": "1.1.1",
+                "events": "^1.1.1",
                 "jmespath": "0.15.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
@@ -19,18 +19,18 @@
             }
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "buffer": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "requires": {
-                "base64-js": "1.3.0",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "events": {
@@ -39,9 +39,9 @@
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "ieee754": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-            "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "isarray": {
             "version": "1.0.0",
@@ -54,9 +54,9 @@
             "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
         "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "punycode": {
             "version": "1.3.2",
@@ -92,8 +92,8 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
             "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
             "requires": {
-                "sax": "1.2.1",
-                "xmlbuilder": "4.2.1"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
             }
         },
         "xmlbuilder": {
@@ -101,7 +101,7 @@
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
             "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.0.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,19 +3,19 @@
     "lockfileVersion": 1,
     "dependencies": {
         "aws-sdk": {
-            "version": "2.205.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.205.0.tgz",
-            "integrity": "sha1-GpNzAlPivgJ6S9OvkkjL2gVz3oA=",
+            "version": "2.535.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.535.0.tgz",
+            "integrity": "sha512-k/ujHppqiEL05jKMPMvABPJhLTxodE/eGLkL9sUjwF5kLcxvzCC6W8K3KbH/pucrKNk5LSz0iQq04+FFvrEy8w==",
             "requires": {
                 "buffer": "4.9.1",
-                "events": "^1.1.1",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
                 "jmespath": "0.15.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
-                "uuid": "3.1.0",
-                "xml2js": "0.4.17",
-                "xmlbuilder": "4.2.1"
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
             }
         },
         "base64-js": {
@@ -53,11 +53,6 @@
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
             "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
-        "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
         "punycode": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -83,26 +78,23 @@
             }
         },
         "uuid": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "xml2js": {
-            "version": "0.4.17",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-            "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "^4.1.0"
+                "xmlbuilder": "~9.0.1"
             }
         },
         "xmlbuilder": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-            "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-            "requires": {
-                "lodash": "^4.0.0"
-            }
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "aws-sdk": "2.205.0"
+        "aws-sdk": "2.535.0"
     }
 }

--- a/src/AWS/Request.purs
+++ b/src/AWS/Request.purs
@@ -3,21 +3,20 @@ module AWS.Request ( MethodName(..)
                    ) where
 
 import Prelude
-import Control.Monad.Aff (Aff)
-import Control.Monad.Aff.Compat (EffFnAff, fromEffFnAff)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import Data.Foreign (Foreign)
-import Data.Foreign.Class (class Decode, class Encode, encode, decode)
+import Effect.Aff (Aff)
+import Effect.Aff.Compat (EffectFnAff, fromEffectFnAff)
+import Effect.Class (liftEffect)
 import F (liftF)
+import Foreign (Foreign)
+import Foreign.Class (class Decode, class Encode, encode, decode)
 
 import AWS.Service (Service(..))
 
 newtype MethodName = MethodName String
 
-foreign import requestImpl :: forall eff. Foreign -> String -> Foreign -> EffFnAff (exception :: EXCEPTION | eff) Foreign
-request :: forall eff i o. Encode i => Decode o => Service -> MethodName -> i -> Aff (exception :: EXCEPTION | eff) o
+foreign import requestImpl :: Foreign -> String -> Foreign -> EffectFnAff Foreign
+request :: forall i o. Encode i => Decode o => Service -> MethodName -> i -> Aff o
 request (Service service) (MethodName method) i = do
     let fi = encode i
-    fo <- requestImpl service method fi # fromEffFnAff
-    decode fo # liftF # liftEff
+    fo <- requestImpl service method fi # fromEffectFnAff
+    decode fo # liftF # liftEffect

--- a/src/AWS/RequestTypes.purs
+++ b/src/AWS/RequestTypes.purs
@@ -3,19 +3,19 @@ module AWS.Request.Types where
 import Prelude
 
 import Data.DateTime.Instant (Instant)
-import Data.Foreign (toForeign, unsafeReadTagged)
-import Data.Foreign.Class (class Decode, class Encode)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
+import Foreign (unsafeToForeign, unsafeReadTagged)
+import Foreign.Class (class Decode, class Encode)
 
 newtype NoArguments = NoArguments {}
 derive instance repGenericNoArguments :: Generic NoArguments _
 instance showNoArguments :: Show NoArguments where show = genericShow
 instance decodeNoArguments :: Decode NoArguments where decode _ = pure $ NoArguments {}
-instance encodeNoArguments :: Encode NoArguments where encode _ = toForeign {}
+instance encodeNoArguments :: Encode NoArguments where encode _ = unsafeToForeign {}
 
 newtype Timestamp = Timestamp Instant
 derive instance repGenericTimestamp :: Generic Timestamp _
 instance showTimestamp :: Show Timestamp where show = genericShow
 instance decodeTimestamp :: Decode Timestamp where decode = unsafeReadTagged "Date"
-instance encodeTimestamp :: Encode Timestamp where encode = toForeign
+instance encodeTimestamp :: Encode Timestamp where encode = unsafeToForeign

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -1,17 +1,17 @@
 module AWS.Service where
 
 import Prelude (class Show, bind, pure, ($))
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import Data.Foreign (Foreign)
-import Data.Foreign.Class (class Encode, encode)
-import Data.Foreign.Generic as Generic
-import Data.Foreign.Generic.Class (class GenericEncode)
+
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, over)
-import Data.StrMap (StrMap)
+import Effect (Effect)
+import Foreign (Foreign)
+import Foreign.Class (class Encode, encode)
+import Foreign.Generic as Generic
+import Foreign.Generic.Class (class GenericEncode)
+import Foreign.Object (Object)
 
 genericEncode :: forall a rep. Generic a rep => GenericEncode rep => a -> Foreign
 genericEncode = Generic.genericEncode $ Generic.defaultOptions { unwrapSingleConstructors = true }
@@ -44,7 +44,7 @@ genericEncode = Generic.genericEncode $ Generic.defaultOptions { unwrapSingleCon
 -- signatureCache (Boolean) — whether the signature to sign requests with (overriding the API configuration) is cached. Only applies to the signature version 'v4'. Defaults to true.
 -- dynamoDbCrc32 (Boolean) — whether to validate the CRC32 checksum of HTTP response bodies returned by DynamoDB. Default: true.
 type OptionsType =
-    { params :: Maybe (StrMap String)
+    { params :: Maybe (Object String)
     , endpoint :: Maybe String
     , accessKeyId :: Maybe String
     , secretAccessKey :: Maybe String
@@ -62,7 +62,7 @@ type OptionsType =
     , retryDelayOptions :: Maybe RetryDelayOptions
     , httpOptions :: Maybe HttpOptions
     , apiVersion :: Maybe String
-    , apiVersions :: Maybe (StrMap String)
+    , apiVersions :: Maybe (Object String)
     , systemClockOffset :: Maybe Int
     , signatureVersion :: Maybe String
     , signatureCache :: Maybe Boolean
@@ -191,8 +191,8 @@ defaultHttpOptions' f = over HttpOptions f defaultHttpOptions
 newtype Service = Service Foreign
 newtype ServiceName = ServiceName String
 
-foreign import serviceImpl :: forall eff. String -> Foreign -> Eff (exception :: EXCEPTION | eff) Foreign
-service :: forall eff. ServiceName -> Options -> Eff (exception :: EXCEPTION | eff) Service
+foreign import serviceImpl :: String -> Foreign -> Effect Foreign
+service :: ServiceName -> Options -> Effect Service
 service (ServiceName name) options = do
     f <- serviceImpl name $ encode options
     pure $ Service f

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -62,7 +62,7 @@ type OptionsType =
     , retryDelayOptions :: Maybe RetryDelayOptions
     , httpOptions :: Maybe HttpOptions
     , apiVersion :: Maybe String
-    , apiVersions :: Maybe (Object String)
+--    , apiVersions :: Maybe (Object String)
     , systemClockOffset :: Maybe Int
     , signatureVersion :: Maybe String
     , signatureCache :: Maybe Boolean
@@ -95,7 +95,7 @@ defaultOptions = Options
     , retryDelayOptions: Nothing
     , httpOptions: Nothing
     , apiVersion: Nothing
-    , apiVersions: Nothing
+--    , apiVersions: Nothing
     , systemClockOffset: Nothing
     , signatureVersion: Nothing
     , signatureCache: Nothing

--- a/src/F.purs
+++ b/src/F.purs
@@ -1,16 +1,16 @@
 module F where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Exception (EXCEPTION, throw)
 import Control.Monad.Except (runExcept)
 import Data.Array (snoc)
 import Data.Either (Either(..))
-import Data.Foreign (F, renderForeignError)
 import Data.List.NonEmpty (foldl)
 import Data.String (joinWith)
+import Effect (Effect)
+import Effect.Exception (throw)
+import Foreign (F, renderForeignError)
 
-liftF :: forall eff a. F a -> Eff (exception :: EXCEPTION | eff) a
+liftF :: forall a. F a -> Effect a
 liftF f = case runExcept f of
     Right identity -> pure identity
     Left exceptions -> exceptions
@@ -18,5 +18,3 @@ liftF f = case runExcept f of
         # map renderForeignError
         # joinWith "\n"
         # throw
-
-

--- a/test/AWS/Request.purs
+++ b/test/AWS/Request.purs
@@ -3,8 +3,9 @@ module Test.AWS.Request where
 import Prelude
 
 import AWS.Request (MethodName(..), request)
-import AWS.Service (ServiceName(..), defaultOptions, service)
+import AWS.Service (ServiceName(..), defaultOptions, defaultOptions', defaultParamValidation, service)
 import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff, attempt, throwError)
 import Effect.Class (liftEffect)
 import Effect.Exception (Error, error, message)
@@ -29,7 +30,7 @@ testRequestUnknownMethod = do
 
 testRequestMissingParameters :: Aff Unit
 testRequestMissingParameters = do
-    s3 <- liftEffect $ service (ServiceName "S3") defaultOptions
+    s3 <- liftEffect $ service (ServiceName "S3") $ defaultOptions' _ { paramValidation = Just defaultParamValidation }
     errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "getBucketVersioning") unit
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 getBucketVersioning should require parameters"

--- a/test/AWS/Request.purs
+++ b/test/AWS/Request.purs
@@ -1,25 +1,25 @@
 module Test.AWS.Request where
 
-import Prelude (Unit, bind, pure, unit, ($), (==))
-import Control.Monad.Aff (Aff, attempt, throwError)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Exception (EXCEPTION, Error, error, message)
-import Data.Either (Either(..))
-import Data.Foreign (Foreign)
+import Prelude
 
-import AWS.Service (ServiceName(..), service, defaultOptions)
 import AWS.Request (MethodName(..), request)
+import AWS.Service (ServiceName(..), defaultOptions, service)
+import Data.Either (Either(..))
+import Effect.Aff (Aff, attempt, throwError)
+import Effect.Class (liftEffect)
+import Effect.Exception (Error, error, message)
+import Foreign (Foreign)
 
-main :: forall eff. Aff (exception :: EXCEPTION | eff) Unit
+main :: Aff Unit
 main = do
     _ <- testRequestUnknownMethod
     _ <- testRequestMissingParameters
 
     pure unit
 
-testRequestUnknownMethod :: forall eff. Aff (exception :: EXCEPTION | eff) Unit
+testRequestUnknownMethod :: Aff Unit
 testRequestUnknownMethod = do
-    s3 <- liftEff $ service (ServiceName "S3") defaultOptions
+    s3 <- liftEffect $ service (ServiceName "S3") defaultOptions
     errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "unknown") unit
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 method unknown shouldn't exist"
@@ -27,9 +27,9 @@ testRequestUnknownMethod = do
             then pure unit
             else throwError err
 
-testRequestMissingParameters :: forall eff. Aff (exception :: EXCEPTION | eff) Unit
+testRequestMissingParameters :: Aff Unit
 testRequestMissingParameters = do
-    s3 <- liftEff $ service (ServiceName "S3") defaultOptions
+    s3 <- liftEffect $ service (ServiceName "S3") defaultOptions
     errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "getBucketVersioning") unit
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 getBucketVersioning should require parameters"

--- a/test/AWS/Service.purs
+++ b/test/AWS/Service.purs
@@ -1,20 +1,20 @@
 module Test.AWS.Service where
 
 import Prelude (Unit, bind, pure, unit, ($), (==))
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Exception (EXCEPTION, message, throw, throwException, try)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Exception (message, throw, throwException, try)
 
 import AWS.Service
 
-main :: forall eff. Eff (exception :: EXCEPTION | eff) Unit
+main :: Effect Unit
 main = do
     _ <- testUnknownService
     _ <- testUpdateOptions
     pure unit
 
-testUnknownService :: forall eff. Eff (exception :: EXCEPTION | eff) Unit
+testUnknownService :: Effect Unit
 testUnknownService = do
     errOrSuccess <- try $ service (ServiceName "unknown") defaultOptions
     case errOrSuccess of
@@ -23,7 +23,7 @@ testUnknownService = do
             then pure unit
             else throwException err
 
-testUpdateOptions :: forall eff. Eff (exception :: EXCEPTION | eff) Unit
+testUpdateOptions :: Effect Unit
 testUpdateOptions = do
     let newHttpOptions = defaultHttpOptions' $ _ { proxy = Just "new-proxy" }
     let newOptions = defaultOptions' $ _ { httpOptions = Just newHttpOptions }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,20 +1,19 @@
 module Test.Main where
 
-import Prelude (Unit, bind, pure, unit, ($))
-import Control.Monad.Aff (Fiber, launchAff)
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Console (CONSOLE, log)
-import Control.Monad.Eff.Exception (EXCEPTION)
+import Prelude
+import Effect (Effect)
+import Effect.Class (liftEffect)
+import Effect.Class.Console (log)
+import Effect.Aff (Fiber, launchAff)
 
 import Test.AWS.Service as Service
 import Test.AWS.Request as Request
 
-main :: forall eff. Eff (exception :: EXCEPTION, console :: CONSOLE | eff) (Fiber (exception :: EXCEPTION, console :: CONSOLE | eff) Unit)
+main :: Effect (Fiber Unit)
 main = launchAff do
-    _ <- liftEff Service.main
-    _ <- liftEff $ log "OK. AWS.Service"
+    _ <- liftEffect Service.main
+    _ <- log "OK. AWS.Service"
     _ <- Request.main
-    _ <- liftEff $ log "OK. AWS.Request"
+    _ <- log "OK. AWS.Request"
 
     pure unit

--- a/wercker.yml
+++ b/wercker.yml
@@ -18,7 +18,7 @@ build:
 
           echo Installing purescript...
           echo '{ "allow_root": true }' > /root/.bowerrc
-          npm install --global --unsafe-perm=true bower pulp purescript@0.11
+          npm install --global --unsafe-perm=true bower pulp purescript@0.13
 
           echo Configurring git...
           git config --global user.email "$GITHUB_SSH_USER_NAME"

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: node:8.9.4
+box: node:12.10.0
 build:
   steps:
     - add-ssh-key:


### PR DESCRIPTION
Upgrade to purescript 0.13
Upgrade of aws-sdk and other js and purescript deps

Had to remove support for `apiVersions` since this was causing failing tests. I'll update aws options to union record types in a future pull req building on this.