### PR TITLE
Record based options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,5 @@ AWS services can be created with a set of options. Most of those are currently s
 - `logger` is missing
 
 - `paramValidation` can't be a `Boolean`
-- `apiVersion` can't be a `Date`
-- `apiVersions` can't contain `Date` objects
-
 - `retryDelayOptions` is missing the `customBackoff` property
 - `httpOptions` is missing the `agent` property

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ AWS services can be created with a set of options. Most of those are currently s
 - `credentials` is missing
 - `credentialProvider` is missing
 - `logger` is missing
-- `apiVersions` is missing
 
 - `paramValidation` can't be a `Boolean`
 - `apiVersion` can't be a `Date`
+- `apiVersions` can't contain `Date` objects
 
 - `retryDelayOptions` is missing the `customBackoff` property
 - `httpOptions` is missing the `agent` property

--- a/README.md
+++ b/README.md
@@ -22,6 +22,5 @@ AWS services can be created with a set of options. Most of those are currently s
 - `credentialProvider` is missing
 - `logger` is missing
 
-- `paramValidation` can't be a `Boolean`
 - `retryDelayOptions` is missing the `customBackoff` property
 - `httpOptions` is missing the `agent` property

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "purescript-exceptions": "^4.0.0",
     "purescript-foreign": "^5.0.0",
     "purescript-simple-json": "^7.0.0",
-    "purescript-generics-rep": "^6.1.1"
+    "purescript-generics-rep": "^6.1.1",
+    "purescript-js-date": "^6.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0"

--- a/bower.json
+++ b/bower.json
@@ -15,11 +15,13 @@
     "purescript-prelude": "^4.1.1",
     "purescript-console": "^4.2.0",
     "purescript-aff": "^5.1.2",
-    "purescript-foreign-generic": "^10.0.0",
     "purescript-datetime": "^4.1.1",
     "purescript-effect": "^2.0.1",
     "purescript-foreign-object": "^2.0.3",
-    "purescript-exceptions": "^4.0.0"
+    "purescript-exceptions": "^4.0.0",
+    "purescript-foreign": "^5.0.0",
+    "purescript-simple-json": "^7.0.0",
+    "purescript-generics-rep": "^6.1.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0"

--- a/docs/AWS.Request.Types.md
+++ b/docs/AWS.Request.Types.md
@@ -11,8 +11,8 @@ newtype NoArguments
 ``` purescript
 Generic NoArguments _
 Show NoArguments
-Decode NoArguments
-Encode NoArguments
+ReadForeign NoArguments
+WriteForeign NoArguments
 ```
 
 #### `Timestamp`
@@ -26,8 +26,8 @@ newtype Timestamp
 ``` purescript
 Generic Timestamp _
 Show Timestamp
-Decode Timestamp
-Encode Timestamp
+ReadForeign Timestamp
+WriteForeign Timestamp
 ```
 
 

--- a/docs/AWS.Request.md
+++ b/docs/AWS.Request.md
@@ -10,7 +10,7 @@ newtype MethodName
 #### `request`
 
 ``` purescript
-request :: forall i o. Encode i => Decode o => Service -> MethodName -> i -> Aff o
+request :: forall i o. WriteForeign i => ReadForeign o => Service -> MethodName -> i -> Aff o
 ```
 
 

--- a/docs/AWS.Service.md
+++ b/docs/AWS.Service.md
@@ -1,141 +1,111 @@
 ## Module AWS.Service
 
-#### `genericEncode`
-
-``` purescript
-genericEncode :: forall a rep. Generic a rep => GenericEncode rep => a -> Foreign
-```
-
 #### `OptionsType`
 
 ``` purescript
-type OptionsType = { accessKeyId :: Maybe String, apiVersion :: Maybe String, computeChecksums :: Maybe Boolean, convertResponseTypes :: Maybe Boolean, correctClockSkew :: Maybe Boolean, dynamoDbCrc32 :: Maybe Boolean, endpoint :: Maybe String, httpOptions :: Maybe HttpOptions, maxRedirects :: Maybe Int, maxRetries :: Maybe Int, paramValidation :: Maybe ParamValidation, params :: Maybe (Object String), region :: Maybe String, retryDelayOptions :: Maybe RetryDelayOptions, s3BucketEndpoint :: Maybe Boolean, s3DisableBodySigning :: Maybe Boolean, s3ForcePathStyle :: Maybe Boolean, secretAccessKey :: Maybe String, signatureCache :: Maybe Boolean, signatureVersion :: Maybe String, sslEnabled :: Maybe Boolean, systemClockOffset :: Maybe Int }
+type OptionsType = (accessKeyId :: String, apiVersion :: ApiVersion, apiVersions :: Object ApiVersion, computeChecksums :: Boolean, convertResponseTypes :: Boolean, correctClockSkew :: Boolean, dynamoDbCrc32 :: Boolean, endpoint :: String, httpOptions :: HttpOptions, maxRedirects :: Int, maxRetries :: Int, paramValidation :: ParamValidation, params :: Object String, region :: String, retryDelayOptions :: RetryDelayOptions, s3BucketEndpoint :: Boolean, s3DisableBodySigning :: Boolean, s3ForcePathStyle :: Boolean, secretAccessKey :: String, signatureCache :: Boolean, signatureVersion :: String, sslEnabled :: Boolean, systemClockOffset :: Int)
 ```
 
 #### `Options`
 
 ``` purescript
-newtype Options
-  = Options OptionsType
+data Options :: Type
 ```
 
-##### Instances
-``` purescript
-Newtype Options _
-Generic Options _
-Show Options
-Encode Options
-```
-
-#### `defaultOptions`
+#### `options`
 
 ``` purescript
-defaultOptions :: Options
-```
-
-#### `defaultOptions'`
-
-``` purescript
-defaultOptions' :: (OptionsType -> OptionsType) -> Options
+options :: forall o _o. Union o _o OptionsType => Record o -> Options
 ```
 
 #### `ParamValidationType`
 
 ``` purescript
-type ParamValidationType = { enum :: Maybe Boolean, max :: Maybe Boolean, min :: Maybe Boolean, pattern :: Maybe Boolean }
+type ParamValidationType = (enum :: Boolean, max :: Boolean, min :: Boolean, pattern :: Boolean)
 ```
 
 #### `ParamValidation`
 
 ``` purescript
-newtype ParamValidation
-  = ParamValidation ParamValidationType
+data ParamValidation :: Type
+```
+
+#### `IsParamValidation`
+
+``` purescript
+class IsParamValidation a 
 ```
 
 ##### Instances
 ``` purescript
-Newtype ParamValidation _
-Generic ParamValidation _
-Show ParamValidation
-Encode ParamValidation
+IsParamValidation Boolean
+(Union o _o ParamValidationType) => IsParamValidation (Record o)
 ```
 
-#### `defaultParamValidation`
+#### `paramValidation`
 
 ``` purescript
-defaultParamValidation :: ParamValidation
-```
-
-#### `defaultParamValidation'`
-
-``` purescript
-defaultParamValidation' :: (ParamValidationType -> ParamValidationType) -> ParamValidation
+paramValidation :: forall a. IsParamValidation a => a -> ParamValidation
 ```
 
 #### `RetryDelayOptionsType`
 
 ``` purescript
-type RetryDelayOptionsType = { base :: Maybe Int }
+type RetryDelayOptionsType = (base :: Int, customBackoff :: Int -> Number)
 ```
 
 #### `RetryDelayOptions`
 
 ``` purescript
-newtype RetryDelayOptions
-  = RetryDelayOptions RetryDelayOptionsType
+data RetryDelayOptions :: Type
 ```
 
-##### Instances
-``` purescript
-Newtype RetryDelayOptions _
-Generic RetryDelayOptions _
-Show RetryDelayOptions
-Encode RetryDelayOptions
-```
-
-#### `defaultRetryDelayOptions`
+#### `retryDelayOptions`
 
 ``` purescript
-defaultRetryDelayOptions :: RetryDelayOptions
-```
-
-#### `defaultRetryDelayOptions'`
-
-``` purescript
-defaultRetryDelayOptions' :: (RetryDelayOptionsType -> RetryDelayOptionsType) -> RetryDelayOptions
+retryDelayOptions :: forall o _o. Union o _o RetryDelayOptionsType => Record o -> RetryDelayOptions
 ```
 
 #### `HttpOptionsType`
 
 ``` purescript
-type HttpOptionsType = { connectTimeout :: Maybe Int, proxy :: Maybe String, timeout :: Maybe Int, xhrAsync :: Maybe Boolean, xhrWithCredentials :: Maybe Boolean }
+type HttpOptionsType = (connectTimeout :: Int, proxy :: String, timeout :: Int, xhrAsync :: Boolean, xhrWithCredentials :: Boolean)
 ```
 
 #### `HttpOptions`
 
 ``` purescript
-newtype HttpOptions
-  = HttpOptions HttpOptionsType
+data HttpOptions :: Type
+```
+
+#### `httpOptions`
+
+``` purescript
+httpOptions :: forall o _o. Union o _o HttpOptionsType => Record o -> HttpOptions
+```
+
+#### `ApiVersion`
+
+``` purescript
+data ApiVersion :: Type
+```
+
+#### `IsApiVersion`
+
+``` purescript
+class IsApiVersion a 
 ```
 
 ##### Instances
 ``` purescript
-Newtype HttpOptions _
-Generic HttpOptions _
-Show HttpOptions
-Encode HttpOptions
+IsApiVersion String
+IsApiVersion JSDate
 ```
 
-#### `defaultHttpOptions`
+#### `apiVersion`
 
 ``` purescript
-defaultHttpOptions :: HttpOptions
-```
-
-#### `defaultHttpOptions'`
-
-``` purescript
-defaultHttpOptions' :: (HttpOptionsType -> HttpOptionsType) -> HttpOptions
+apiVersion :: forall a. IsApiVersion a => a -> ApiVersion
 ```
 
 #### `Service`
@@ -161,7 +131,13 @@ serviceImpl :: String -> Foreign -> Effect Foreign
 #### `service`
 
 ``` purescript
-service :: ServiceName -> Options -> Effect Service
+service :: forall o _o. Union o _o OptionsType => ServiceName -> Record o -> Effect Service
+```
+
+#### `service'`
+
+``` purescript
+service' :: ServiceName -> Options -> Effect Service
 ```
 
 

--- a/src/AWS/Request.purs
+++ b/src/AWS/Request.purs
@@ -3,20 +3,20 @@ module AWS.Request ( MethodName(..)
                    ) where
 
 import Prelude
+
+import AWS.Service (Service(..))
 import Effect.Aff (Aff)
 import Effect.Aff.Compat (EffectFnAff, fromEffectFnAff)
 import Effect.Class (liftEffect)
 import F (liftF)
 import Foreign (Foreign)
-import Foreign.Class (class Decode, class Encode, encode, decode)
-
-import AWS.Service (Service(..))
+import Simple.JSON (class ReadForeign, class WriteForeign, readImpl, writeImpl)
 
 newtype MethodName = MethodName String
 
 foreign import requestImpl :: Foreign -> String -> Foreign -> EffectFnAff Foreign
-request :: forall i o. Encode i => Decode o => Service -> MethodName -> i -> Aff o
+request :: forall i o. WriteForeign i => ReadForeign o => Service -> MethodName -> i -> Aff o
 request (Service service) (MethodName method) i = do
-    let fi = encode i
+    let fi = writeImpl i
     fo <- requestImpl service method fi # fromEffectFnAff
-    decode fo # liftF # liftEffect
+    readImpl fo # liftF # liftEffect

--- a/src/AWS/RequestTypes.purs
+++ b/src/AWS/RequestTypes.purs
@@ -6,16 +6,16 @@ import Data.DateTime.Instant (Instant)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Foreign (unsafeToForeign, unsafeReadTagged)
-import Foreign.Class (class Decode, class Encode)
+import Simple.JSON (class ReadForeign, class WriteForeign)
 
 newtype NoArguments = NoArguments {}
 derive instance repGenericNoArguments :: Generic NoArguments _
 instance showNoArguments :: Show NoArguments where show = genericShow
-instance decodeNoArguments :: Decode NoArguments where decode _ = pure $ NoArguments {}
-instance encodeNoArguments :: Encode NoArguments where encode _ = unsafeToForeign {}
+instance readNoArguments :: ReadForeign NoArguments where readImpl _ = pure $ NoArguments {}
+instance writeNoArguments :: WriteForeign NoArguments where writeImpl _ = unsafeToForeign {}
 
 newtype Timestamp = Timestamp Instant
 derive instance repGenericTimestamp :: Generic Timestamp _
 instance showTimestamp :: Show Timestamp where show = genericShow
-instance decodeTimestamp :: Decode Timestamp where decode = unsafeReadTagged "Date"
-instance encodeTimestamp :: Encode Timestamp where encode = unsafeToForeign
+instance readTimestamp :: ReadForeign Timestamp where readImpl = unsafeReadTagged "Date"
+instance writeTimestamp :: WriteForeign Timestamp where writeImpl = unsafeToForeign

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -1,21 +1,11 @@
 module AWS.Service where
 
-import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
-import Data.Maybe (Maybe(..))
-import Data.Newtype (class Newtype, over)
+import Prelude
 import Effect (Effect)
 import Foreign (Foreign, unsafeToForeign)
-import Foreign.Class (class Encode)
-import Foreign.Generic as Generic
-import Foreign.Generic.Class (class GenericEncode)
 import Foreign.Object (Object)
-import Prelude (class Show, bind, pure, ($))
 import Prim.Row (class Union)
 import Unsafe.Coerce (unsafeCoerce)
-
-genericEncode :: forall a rep. Generic a rep => GenericEncode rep => a -> Foreign
-genericEncode = Generic.genericEncode $ Generic.defaultOptions { unwrapSingleConstructors = true }
 
 -- params (map) — An optional map of parameters to bind to every request sent by this service object. For more information on bound parameters, see "Working with Services" in the Getting Started Guide.
 -- endpoint (String) — The endpoint URI to send requests to. The default endpoint is built from the configured region. The endpoint should be a string like 'https://{service}.{region}.amazonaws.com'.

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -101,22 +101,14 @@ paramValidation = unsafeCoerce
 --   - base [Integer] — The base number of milliseconds to use in the exponential backoff for operation retries. Defaults to 100 ms for all services except DynamoDB, where it defaults to 50ms.
 --   - customBackoff [function] — A custom function that accepts a retry count and returns the amount of time to delay in milliseconds. The base option will be ignored if this option is supplied.
 type RetryDelayOptionsType =
-    { base :: Maybe Int
-    }
+    ( base :: Int
+    , customBackoff :: Int -> Number
+    )
 
-newtype RetryDelayOptions = RetryDelayOptions RetryDelayOptionsType
-derive instance newtypeRetryDelayOptions :: Newtype RetryDelayOptions _
-derive instance repGenericRetryDelayOptions :: Generic RetryDelayOptions _
-instance showRetryDelayOptions :: Show RetryDelayOptions where show = genericShow
-instance encodeRetryDelayOptions :: Encode RetryDelayOptions where encode = genericEncode
+foreign import data RetryDelayOptions :: Type
 
-defaultRetryDelayOptions :: RetryDelayOptions
-defaultRetryDelayOptions = RetryDelayOptions
-    { base: Nothing
-    }
-
-defaultRetryDelayOptions' :: (RetryDelayOptionsType -> RetryDelayOptionsType) -> RetryDelayOptions
-defaultRetryDelayOptions' f = over RetryDelayOptions f defaultRetryDelayOptions
+retryDelayOptions :: forall o _o. Union o _o RetryDelayOptionsType => { |o } -> RetryDelayOptions
+retryDelayOptions = unsafeCoerce
 
 -- A set of options to pass to the low-level HTTP request.
 --   - proxy [String] — the URL to proxy requests through

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -118,30 +118,17 @@ retryDelayOptions = unsafeCoerce
 --   - xhrAsync [Boolean] — Whether the SDK will send asynchronous HTTP requests. Used in the browser environment only. Set to false to send requests synchronously. Defaults to true (async on).
 --   - xhrWithCredentials [Boolean] — Sets the "withCredentials" property of an XMLHttpRequest object. Used in the browser environment only. Defaults to false.
 type HttpOptionsType =
-    { proxy :: Maybe String
-    , connectTimeout :: Maybe Int
-    , timeout :: Maybe Int
-    , xhrAsync :: Maybe Boolean
-    , xhrWithCredentials :: Maybe Boolean
-    }
+    ( proxy :: String
+    , connectTimeout :: Int
+    , timeout :: Int
+    , xhrAsync :: Boolean
+    , xhrWithCredentials :: Boolean
+    )
 
-newtype HttpOptions = HttpOptions HttpOptionsType
-derive instance newtypeHttpOptions :: Newtype HttpOptions _
-derive instance repGenericHttpOptions :: Generic HttpOptions _
-instance showHttpOptions :: Show HttpOptions where show = genericShow
-instance encodeHttpOptions :: Encode HttpOptions where encode = genericEncode
+foreign import data HttpOptions :: Type
 
-defaultHttpOptions :: HttpOptions
-defaultHttpOptions = HttpOptions
-    { proxy: Nothing
-    , connectTimeout: Nothing
-    , timeout: Nothing
-    , xhrAsync: Nothing
-    , xhrWithCredentials: Nothing
-    }
-
-defaultHttpOptions' :: (HttpOptionsType -> HttpOptionsType) -> HttpOptions
-defaultHttpOptions' f = over HttpOptions f defaultHttpOptions
+httpOptions :: forall o _o. Union o _o HttpOptionsType => { |o } -> HttpOptions
+httpOptions = unsafeCoerce
 
 newtype Service = Service Foreign
 newtype ServiceName = ServiceName String

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -81,28 +81,21 @@ options = unsafeCoerce
 --   - pattern [Boolean] — Validates that a string value matches a regular expression.
 --   - enum [Boolean] — Validates that a string value matches one of the allowable enum values.
 type ParamValidationType =
-    { min :: Maybe Boolean
-    , max :: Maybe Boolean
-    , pattern :: Maybe Boolean
-    , enum :: Maybe Boolean
-    }
+    ( min :: Boolean
+    , max :: Boolean
+    , pattern :: Boolean
+    , enum :: Boolean
+    )
 
-newtype ParamValidation = ParamValidation ParamValidationType
-derive instance newtypeParamValidation :: Newtype ParamValidation _
-derive instance repGenericParamValidation :: Generic ParamValidation _
-instance showParamValidation :: Show ParamValidation where show = genericShow
-instance encodeParamValidation :: Encode ParamValidation where encode = genericEncode
+foreign import data ParamValidation :: Type
 
-defaultParamValidation :: ParamValidation
-defaultParamValidation = ParamValidation
-    { min: Nothing
-    , max: Nothing
-    , pattern: Nothing
-    , enum: Nothing
-    }
+class IsParamValidation a
 
-defaultParamValidation' :: (ParamValidationType -> ParamValidationType) -> ParamValidation
-defaultParamValidation' f = over ParamValidation f defaultParamValidation
+instance isParamValidationBoolean :: IsParamValidation Boolean
+instance isParamValidationRecord :: Union o _o ParamValidationType => IsParamValidation { |o }
+
+paramValidation :: forall a. IsParamValidation a => a -> ParamValidation
+paramValidation = unsafeCoerce
 
 -- A set of options to configure the retry delay on retryable errors.
 --   - base [Integer] — The base number of milliseconds to use in the exponential backoff for operation retries. Defaults to 100 ms for all services except DynamoDB, where it defaults to 50ms.

--- a/src/AWS/Service.purs
+++ b/src/AWS/Service.purs
@@ -1,6 +1,8 @@
 module AWS.Service where
 
 import Prelude
+
+import Data.JSDate (JSDate)
 import Effect (Effect)
 import Foreign (Foreign, unsafeToForeign)
 import Foreign.Object (Object)
@@ -52,8 +54,8 @@ type OptionsType =
     , s3DisableBodySigning :: Boolean
     , retryDelayOptions :: RetryDelayOptions
     , httpOptions :: HttpOptions
-    , apiVersion :: String
-    , apiVersions :: Object String
+    , apiVersion :: ApiVersion
+    , apiVersions :: Object ApiVersion
     , systemClockOffset :: Int
     , signatureVersion :: String
     , signatureCache :: Boolean
@@ -119,6 +121,16 @@ foreign import data HttpOptions :: Type
 
 httpOptions :: forall o _o. Union o _o HttpOptionsType => { |o } -> HttpOptions
 httpOptions = unsafeCoerce
+
+foreign import data ApiVersion :: Type
+
+class IsApiVersion a
+
+instance isApiVersionString :: IsApiVersion String
+instance isApiVersionJSDate :: IsApiVersion JSDate
+
+apiVersion :: forall a. IsApiVersion a => a -> ApiVersion
+apiVersion = unsafeCoerce
 
 newtype Service = Service Foreign
 newtype ServiceName = ServiceName String

--- a/test/AWS/Request.purs
+++ b/test/AWS/Request.purs
@@ -3,7 +3,7 @@ module Test.AWS.Request where
 import Prelude
 
 import AWS.Request (MethodName(..), request)
-import AWS.Service (ServiceName(..), defaultParamValidation, service)
+import AWS.Service (ServiceName(..), paramValidation, service)
 import Data.Either (Either(..))
 import Effect.Aff (Aff, attempt, throwError)
 import Effect.Class (liftEffect)
@@ -29,7 +29,7 @@ testRequestUnknownMethod = do
 
 testRequestMissingParameters :: Aff Unit
 testRequestMissingParameters = do
-    s3 <- liftEffect $ service (ServiceName "S3") $ { paramValidation: defaultParamValidation }
+    s3 <- liftEffect $ service (ServiceName "S3") $ { paramValidation: paramValidation true }
     errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "getBucketVersioning") unit
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 getBucketVersioning should require parameters"

--- a/test/AWS/Request.purs
+++ b/test/AWS/Request.purs
@@ -20,7 +20,7 @@ main = do
 testRequestUnknownMethod :: Aff Unit
 testRequestUnknownMethod = do
     s3 <- liftEffect $ service (ServiceName "S3") {}
-    errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "unknown") unit
+    errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "unknown") {}
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 method unknown shouldn't exist"
         Left err -> if (message err) == "service[methodName] is not a function"
@@ -30,7 +30,7 @@ testRequestUnknownMethod = do
 testRequestMissingParameters :: Aff Unit
 testRequestMissingParameters = do
     s3 <- liftEffect $ service (ServiceName "S3") $ { paramValidation: paramValidation true }
-    errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "getBucketVersioning") unit
+    errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "getBucketVersioning") {}
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 getBucketVersioning should require parameters"
         Left err -> if (message err) == "Missing required key 'Bucket' in params"

--- a/test/AWS/Request.purs
+++ b/test/AWS/Request.purs
@@ -3,9 +3,8 @@ module Test.AWS.Request where
 import Prelude
 
 import AWS.Request (MethodName(..), request)
-import AWS.Service (ServiceName(..), defaultOptions, defaultOptions', defaultParamValidation, service)
+import AWS.Service (ServiceName(..), defaultParamValidation, service)
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff, attempt, throwError)
 import Effect.Class (liftEffect)
 import Effect.Exception (Error, error, message)
@@ -20,7 +19,7 @@ main = do
 
 testRequestUnknownMethod :: Aff Unit
 testRequestUnknownMethod = do
-    s3 <- liftEffect $ service (ServiceName "S3") defaultOptions
+    s3 <- liftEffect $ service (ServiceName "S3") {}
     errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "unknown") unit
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 method unknown shouldn't exist"
@@ -30,7 +29,7 @@ testRequestUnknownMethod = do
 
 testRequestMissingParameters :: Aff Unit
 testRequestMissingParameters = do
-    s3 <- liftEffect $ service (ServiceName "S3") $ defaultOptions' _ { paramValidation = Just defaultParamValidation }
+    s3 <- liftEffect $ service (ServiceName "S3") $ { paramValidation: defaultParamValidation }
     errOrSuccess :: Either Error Foreign <- attempt $ request s3 (MethodName "getBucketVersioning") unit
     case errOrSuccess of
         Right succ -> throwError $ error "AWS S3 getBucketVersioning should require parameters"

--- a/test/AWS/Service.purs
+++ b/test/AWS/Service.purs
@@ -2,7 +2,6 @@ module Test.AWS.Service where
 
 import Prelude (Unit, bind, pure, unit, ($), (==))
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (message, throw, throwException, try)
 
@@ -25,7 +24,7 @@ testUnknownService = do
 
 testUpdateOptions :: Effect Unit
 testUpdateOptions = do
-    let newHttpOptions = defaultHttpOptions' $ _ { proxy = Just "new-proxy" }
+    let newHttpOptions = httpOptions { proxy: "new-proxy" }
     let newOptions = { httpOptions: newHttpOptions }
     _ <- service (ServiceName "S3") newOptions
     pure unit

--- a/test/AWS/Service.purs
+++ b/test/AWS/Service.purs
@@ -16,7 +16,7 @@ main = do
 
 testUnknownService :: Effect Unit
 testUnknownService = do
-    errOrSuccess <- try $ service (ServiceName "unknown") defaultOptions
+    errOrSuccess <- try $ service (ServiceName "unknown") {}
     case errOrSuccess of
         Right succ -> throw "AWS service unknown shouldn't exist"
         Left err -> if (message err) == "awsSdk[serviceName] is not a constructor"
@@ -26,6 +26,6 @@ testUnknownService = do
 testUpdateOptions :: Effect Unit
 testUpdateOptions = do
     let newHttpOptions = defaultHttpOptions' $ _ { proxy = Just "new-proxy" }
-    let newOptions = defaultOptions' $ _ { httpOptions = Just newHttpOptions }
+    let newOptions = { httpOptions: newHttpOptions }
     _ <- service (ServiceName "S3") newOptions
     pure unit


### PR DESCRIPTION
* Fixes #37 
* Adds back apiVersions
* Add support for boolean `paramValidation` and JSDate `apiVersion`
* Switches to simple-json instead of foreign-generic